### PR TITLE
STOP USING ModuleUnderTest.js -AND- temporarly reference src as main in package.json 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,7 @@
     "it":       true  // it()       is part of our unit test framework
   },
   "rules": {
+    "no-console":      "off",                       // allow console logging
     "strict":          ["error", "never"],          // ES6 Modules imply a 'use strict'; ... specifying this is redundant
     "indent":          ["off",   2],                // allow any indentation
     "no-unused-vars":  ["error", {"args": "none"}], // allow unsed parameter declaration 

--- a/SCRIPTS.md
+++ b/SCRIPTS.md
@@ -35,7 +35,8 @@ prepublish .............. cleanly build/test all machine generated resources,
                             - verify code quality (lint)
                             - show outdated installed packages
                             - clean (delete) ALL machine generated resources
-                            - build/test all bundled libraries (for publication)
+                            - build all bundled libraries (for publication)
+                            - test (against our master src)
                             - generate the code coverage report
 
 
@@ -43,26 +44,8 @@ prepublish .............. cleanly build/test all machine generated resources,
 TESTING
 =======
 
-test ................... run ALL unit tests on master src (same as 'test:all' or 'test:plat:src')
-
-                         Following runs SELECTED tests ON master src
-                         ===========================================
-test:lib ............... run unit tests that are part of our published library  TODO: NOT yet in feature-u
-test:lib:watch ......... ditto (continuously)                                   TODO: NOT yet in feature-u
-test:samples ........... run unit tests from our sample code (in the Dev Guide) TODO: NOT yet in feature-u
-test:samples:watch ..... ditto (continuously)                                   TODO: NOT yet in feature-u
-test:all ............... run ALL our unit tests
-test:all:watch ......... ditto (continuously)
-
-                         Following runs ALL tests ON specified Target Platform
-                         =====================================================
-test:plat:{platform} ... see discussion below
-test:plat:src
-test:plat:bundle
-test:plat:bundle.min
-test:plat:lib
-test:plat:es
-test:plat:all
+test ......... run ALL unit tests on master src
+test:watch ... ditto (continuously)
 
 
 CODE QUALITY
@@ -115,41 +98,6 @@ clean ... cleans ALL machine-generated directories (build, and coverage)
 ```
 
 
-
-## Testing Dynamics
-
-Our unit tests have the ability to dynamically target each of our
-published platforms, through the `test:plat:{platform}` script (see the
-[Target Platform](#target-platform) discussion below).
-
-- During development, our tests typically target the master src
-  directly, and continuously (through the `test:lib:watch` script).
-  
-- However, before any bundle is published, it is a good practice to run
-  our test suite against each of the published bundles (through the
-  `test:plat:all` script).
-
-Testing dynamics is accomplished by our unit tests importing
-[ModuleUnderTest](tooling/ModuleUnderTest.js), which in turn
-dynamically exports the desired test module, as controlled by the
-MODULE_PLATFORM environment variable.
-
-**There is one slight QUIRK in this process** ... that is: *ALL
-supported platforms MUST exist before you can test one of them*.  The
-reason for this is that
-[ModuleUnderTest.js](tooling/ModuleUnderTest.js) must import all
-the platforms and then decide which one to export *(this is due to the
-static nature of ES6 imports)*.
-
-**As it turns out, this is not a big deal**, it's just a bit of
-un-expected behavior.  During development, our tests typically
-continuously target the master src (which doesn't require any
-re-building).  So the `build:plat:all` script **does NOT have to be run
-continuously ... just once, after a clean** (to prime the pump).
-
-
-
-
 ## Target Platform
 
 Some npm scripts target a platform (i.e. the JS module ecosystem),
@@ -158,7 +106,6 @@ using 'plat' nomenclature (i.e. platform).
 Specifically:
 
  - `build:plat:{platform}`
- - `test:plat:{platform}`
 
 Supported platforms are:
 
@@ -173,7 +120,3 @@ lib              ES5 source           CommonJS  lib/*.js
 es               ES5 source           ES        es/*.js                                        
 all              all of the above                                      Used in npm scripts ONLY
 ```
-
-The 'plat' nomenclature helps disambiguate the difference between (for example):
- - `test:all:     ` identifies WHICH tests to run (i.e. all tests)
- - `test:plat:all:` identifies WHICH platform to run tests on (i.e. all platforms)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "feature-u",
   "version": "0.1.0",
   "description": "Feature Based Project Organization for React",
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "browser": {
     "main": "dist/feature-u.js"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "feature-u",
   "version": "0.1.0",
   "description": "Feature Based Project Organization for React",
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "browser": {
     "main": "dist/feature-u.js"
   },
@@ -36,7 +36,7 @@
     "cov":                   "jest src --coverage",
     "cov:clean":             "rimraf coverage",
     "cov:publish":           "cat coverage/lcov.info | codacy-coverage --verbose",
-    "dev":                   "npm run test:all:watch",
+    "dev":                   "npm run test:watch",
     "docs":                  "npm run docs:prepare && npm run docs:build",
     "docs:api":              "jsdoc2md --configure tooling/docs/jsdoc.json --global-index-format none --helper tooling/docs/escapeAnchor.js --partial tooling/docs/header.hbs --partial tooling/docs/link.hbs --partial tooling/docs/body.hbs --files src/**/*.js > docs/api.md",
     "docs:prepare":          "gitbook install",
@@ -49,17 +49,10 @@
     "docs:clean":            "rimraf _book _docs/cur",
     "lint":                  "echo '*** Verify code quality (lint):' && eslint src",
     "pkgReview":             "echo '*** Showing outdated installed packages:' && npm outdated --long || true",
-    "prepublish":            "npm-run-all lint pkgReview clean build:plat:all test:plat:all cov",
+    "prepublish":            "npm-run-all lint pkgReview clean build:plat:all test cov",
     "start":                 "npm run dev",
     "test":                  "jest src",
-    "test:all":              "npm run test         --",
-    "test:all:watch":        "npm run test:all     -- --watch",
-    "test:plat:all":         "npm-run-all test:plat:src test:plat:bundle test:plat:bundle.min test:plat:lib test:plat:es",
-    "test:plat:bundle":      "cross-env MODULE_PLATFORM=bundle     npm run test:all",
-    "test:plat:bundle.min":  "cross-env MODULE_PLATFORM=bundle.min npm run test:all",
-    "test:plat:es":          "cross-env MODULE_PLATFORM=es         npm run test:all",
-    "test:plat:lib":         "cross-env MODULE_PLATFORM=lib        npm run test:all",
-    "test:plat:src":         "cross-env MODULE_PLATFORM=src        npm run test:all"
+    "test:watch":            "npm run test -- --watch"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "feature-u",
   "version": "0.1.0",
   "description": "Feature Based Project Organization for React",
-  "main": "src/index.js",
+  "main": "lib/index.js",
   "browser": {
     "main": "dist/feature-u.js"
   },

--- a/src/extend/spec/createAspect.spec.js
+++ b/src/extend/spec/createAspect.spec.js
@@ -1,6 +1,6 @@
 import {createAspect,     // module under test
         createFeature,
-        managedExpansion} from '../../../tooling/ModuleUnderTest';
+        managedExpansion} from '../..'; // STOP USING: '../../../tooling/ModuleUnderTest';
 
 const identityFn = p => p;
 

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -71,7 +71,13 @@ const webpackConfig = {
       // apply style check with eslint
       // ... NOTE: This is production code only (i.e. what is being bundled).
       //           To check test code, use the npm lint script.
-      { test: /\.(js|jsx)$/,  use: 'eslint-loader' }
+//*1* { test: /\.(js|jsx)$/,  use: 'eslint-loader' },
+//*1* 2/19/2018: I disabled this eslint step BECAUSE 
+//     - it was erroring on code picked up from my node_modules that has been transpiled to es5 (i.e. feature-u)
+//       ex: C:\dev\feature-u\es\index.js
+//           1:1  error  'use strict' is unnecessary inside of modules  strict
+//     - my thought is I only care about MY code being eslint correct (which is verified externally), NOT my dependent packages
+//     - UNSURE of the full ramifications of this
     ]
   },
   plugins: [] // NOTE: WebPack 2 auto includes webpack.optimize.OccurrenceOrderPlugin, so there is NO need to specify it!


### PR DESCRIPTION
temporary change allows plugin dependancy of github branch prior to being published