### PR TITLE
App Life Cycle Hooks PROMOTE getState function RATHER-THAN appState object

### DIFF
--- a/src/core/launchApp.js
+++ b/src/core/launchApp.js
@@ -730,18 +730,18 @@ op.flch.appInit = function(fassets, activeFeatures, aspects, showStatus) {
     logf(`feature-life-cycle-hook ... PROCESSING: Feature.appInit() ... ${hookCount} hooks:${hookSummary}`);
     
     // locate the redux app store (if any) from our aspects
-    // ... used as a convenience to pass appState/dispatch to appInit()
+    // ... used as a convenience to pass getState/dispatch to appInit()
     // ... we define this from the cross-aspect redux method: Aspect.getReduxStore()
     const reduxAspect = aspects.find( aspect => aspect.getReduxStore ? true : false );
-    const [appState, dispatch] = reduxAspect 
-                               ? [reduxAspect.getReduxStore().getState(), reduxAspect.getReduxStore().dispatch]
+    const [getState, dispatch] = reduxAspect 
+                               ? [reduxAspect.getReduxStore().getState, reduxAspect.getReduxStore().dispatch]
                                : [undefined, undefined];
     
     // invoke Feature.appInit() life-cycle hooks
     // ... accomplished in AsyncInit class
     const asyncInits = activeFeatures.reduce( (accum, feature) => {
       if (feature.appInit) {
-        accum.push( new AsyncInit(feature, fassets, appState, dispatch, showStatus, monitorNextAsyncInit) );
+        accum.push( new AsyncInit(feature, fassets, getState, dispatch, showStatus, monitorNextAsyncInit) );
       }
       return accum;
     }, []);
@@ -790,7 +790,7 @@ class AsyncInit {
   // class constructor
   constructor(feature,       // feature KNOWN TO HAVE appInit() hook
               fassets,
-              appState,
+              getState,
               dispatch,
               showStatusApp, // the app-specific showStatus() callback function
               monitorNextAsyncInit) {
@@ -813,7 +813,7 @@ class AsyncInit {
     try {
       optionalPromise = feature.appInit({showStatus: this.showStatus,
                                          fassets,
-                                         appState,
+                                         getState,
                                          dispatch});
     }
     catch(err) {
@@ -898,18 +898,18 @@ op.flch.appDidStart = function(fassets, activeFeatures, aspects) {
   logf(`feature-life-cycle-hook ... PROCESSING: Feature.appDidStart() ... ${hookCount} hooks:${hookSummary}`);
 
   // locate the redux app store (if any) from our aspects
-  // ... used as a convenience to pass appState/dispatch to appDidStart()
+  // ... used as a convenience to pass getState/dispatch to appDidStart()
   // ... we define this from the cross-aspect redux method: Aspect.getReduxStore()
   const reduxAspect = aspects.find( aspect => aspect.getReduxStore ? true : false );
-  const [appState, dispatch] = reduxAspect 
-                                ? [reduxAspect.getReduxStore().getState(), reduxAspect.getReduxStore().dispatch]
+  const [getState, dispatch] = reduxAspect 
+                                ? [reduxAspect.getReduxStore().getState, reduxAspect.getReduxStore().dispatch]
                                 : [undefined, undefined];
 
   // apply Feature.appDidStart() life-cycle hooks
   activeFeatures.forEach( feature => {
     if (feature.appDidStart) {
       logf(`feature-life-cycle-hook ... Feature.name:${feature.name} ... invoking it's defined Feature.appDidStart()`);
-      feature.appDidStart({fassets, appState, dispatch});
+      feature.appDidStart({fassets, getState, dispatch});
     }
   });
 };

--- a/src/core/spec/launchApp.op.flch.appDidStart.spec.js
+++ b/src/core/spec/launchApp.op.flch.appDidStart.spec.js
@@ -15,8 +15,8 @@ describe('launchApp.op.flch.appDidStart(fassets, activeFeatures, aspects): void'
 
     let accumFromAppDidStart = '';
 
-    function appDidStart({fassets, appState, dispatch}) { // reusable function
-      accumFromAppDidStart += `appDidStart for feature: ${this.name} (fassets: ${fassets}, appState: ${appState}, dispatch: ${dispatch})`;
+    function appDidStart({fassets, getState, dispatch}) { // reusable function
+      accumFromAppDidStart += `appDidStart for feature: ${this.name} (fassets: ${fassets}, getState: ${getState ? getState() : undefined}, dispatch: ${dispatch})`;
     }
 
     const activeFeatures = [
@@ -55,8 +55,8 @@ describe('launchApp.op.flch.appDidStart(fassets, activeFeatures, aspects): void'
 
     applyTest({
       aspects: [], // no aspects
-      expected: 'appDidStart for feature: feature1 (fassets: fassets-pass-through-for-testing, appState: undefined, dispatch: undefined)' +
-                'appDidStart for feature: feature3 (fassets: fassets-pass-through-for-testing, appState: undefined, dispatch: undefined)',
+      expected: 'appDidStart for feature: feature1 (fassets: fassets-pass-through-for-testing, getState: undefined, dispatch: undefined)' +
+                'appDidStart for feature: feature3 (fassets: fassets-pass-through-for-testing, getState: undefined, dispatch: undefined)',
     });
 
   });
@@ -75,8 +75,8 @@ describe('launchApp.op.flch.appDidStart(fassets, activeFeatures, aspects): void'
           },
         }),
       ],
-      expected: 'appDidStart for feature: feature1 (fassets: fassets-pass-through-for-testing, appState: pretendState, dispatch: pretendDispatch)' +
-                'appDidStart for feature: feature3 (fassets: fassets-pass-through-for-testing, appState: pretendState, dispatch: pretendDispatch)',
+      expected: 'appDidStart for feature: feature1 (fassets: fassets-pass-through-for-testing, getState: pretendState, dispatch: pretendDispatch)' +
+                'appDidStart for feature: feature3 (fassets: fassets-pass-through-for-testing, getState: pretendState, dispatch: pretendDispatch)',
     });
 
   });


### PR DESCRIPTION
In some cases, the instantaneous `appState` is not enough.
In my sample, we imagine a axios configuration trough interceptors.

When the user is not authenticated, the request interceptor is not modifed.
When the user is authenticated, the jwt token is set.

Let's see how to do it in a feature context :

(It works the same way with appInit)

**configureAxios.js**
```js
export default (fassets, appState) => {
  // We intercept Axios calls to add authentication headers
  axios.interceptors.request.use(
    async (requestConfig) => {

      if (fassets.auth.isAuth(appState)) {

        const authHeaders = {
          apiKey: Config.API_KEY,
          Authentication: `Bearer ${fassets.auth.getJwtToken(appState)}`,
        }

        const { headers } = requestConfig
        const newHeaders = {
          ...headers,
          ...authHeaders,
        }
        requestConfig.headers = newHeaders

        return requestConfig

      } else {
        return requestConfig

      }
    },
    (error) => {
      console.error(error)
      return error
    },
  )
}
```

**kernel/feature.js**
```js
export default createFeature({
  name: 'kernel',
  appDidStart: ({fassets, appState}) => { configureAxios(fassets, appState) }
```

In that situation, appState *always* have the same value : the value he had when appDidStart was call. If the user authenticates, the interceptor doesn't know about it and the app ins't working.

------
Now, if we provide the `appDidStart` the `getState` instead of the `appState`, the `configureAxios` is able to retrieve the up-to-date state and works as expected during the all app execution.

In that case, the code will be : 

**configureAxios.js**
```js
export default (fassets, getState) => {
  // We intercept Axios calls to add authentication headers
  axios.interceptors.request.use(
    async (requestConfig) => {

      if (fassets.auth.isAuth(getState())) {

        const authHeaders = {
          apiKey: Config.API_KEY,
          Authentication: `Bearer ${fassets.auth.getJwtToken(getState())}`,
        }

        const { headers } = requestConfig
        const newHeaders = {
          ...headers,
          ...authHeaders,
        }
        requestConfig.headers = newHeaders

        return requestConfig

      } else {
        return requestConfig

      }
    },
    (error) => {
      console.error(error)
      return error
    },
  )
}
```

**kernel/feature.js**
```js
export default createFeature({
  name: 'kernel',
  appDidStart: ({fassets, getState}) => { configureAxios(fassets, getState) }
```